### PR TITLE
🔧 jacoco, codecov 적용

### DIFF
--- a/.github/workflows/codecov-test.yml
+++ b/.github/workflows/codecov-test.yml
@@ -1,0 +1,30 @@
+name: Java CI with Gradle
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - feature/issue-4
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,13 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.0.0"
-	id("io.spring.dependency-management") version "1.1.0"
-	id("org.asciidoctor.jvm.convert") version "3.3.2"
-	kotlin("jvm") version "1.7.21"
-	kotlin("plugin.spring") version "1.7.21"
-	kotlin("plugin.jpa") version "1.7.21"
+    id("org.springframework.boot") version "3.0.0"
+    id("io.spring.dependency-management") version "1.1.0"
+    id("org.asciidoctor.jvm.convert") version "3.3.2"
+    kotlin("jvm") version "1.7.21"
+    kotlin("plugin.spring") version "1.7.21"
+    kotlin("plugin.jpa") version "1.7.21"
+    jacoco
 }
 
 group = "com.yapp"
@@ -14,83 +15,132 @@ version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("com.coveo:spring-boot-parameter-store-integration:1.5.0")
-	runtimeOnly("com.h2database:h2")
-	runtimeOnly("com.mysql:mysql-connector-j")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	implementation("org.springframework.boot:spring-boot-starter-actuator")
-	// Spring Rest Docs
-	testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
-	testImplementation("org.springframework.restdocs:spring-restdocs-asciidoctor")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("com.coveo:spring-boot-parameter-store-integration:1.5.0")
+    runtimeOnly("com.h2database:h2")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    // Spring Rest Docs
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+    testImplementation("org.springframework.restdocs:spring-restdocs-asciidoctor")
+}
+
+jacoco {
+    toolVersion = "0.8.8"
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "17"
-	}
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+    useJUnitPlatform()
+    finalizedBy("jacocoTestReport")
 }
 
 tasks.getByName<Jar>("jar") {
     enabled = false
 }
+
 tasks {
-	val snippetsDir = file("$buildDir/generated-snippets")
+    val snippetsDir = file("$buildDir/generated-snippets")
 
-	clean {
-		delete("src/main/resources/static/docs")
-	}
+    clean {
+        delete("src/main/resources/static/docs")
+    }
 
-	test {
-		useJUnitPlatform()
-		systemProperty("org.springframework.restdocs.outputDir", snippetsDir)
-		outputs.dir(snippetsDir)
-	}
+    test {
+        useJUnitPlatform()
+        systemProperty("org.springframework.restdocs.outputDir", snippetsDir)
+        outputs.dir(snippetsDir)
+    }
 
-	build {
-		dependsOn("copyDocument")
-	}
+    build {
+        dependsOn("copyDocument")
+    }
 
-	asciidoctor {
-		dependsOn(test)
+    asciidoctor {
+        dependsOn(test)
 
-		attributes(
-			mapOf("snippets" to snippetsDir)
-		)
-		inputs.dir(snippetsDir)
+        attributes(
+                mapOf("snippets" to snippetsDir)
+        )
+        inputs.dir(snippetsDir)
 
-		doFirst {
-			delete("src/main/resources/static/docs")
-		}
-	}
+        doFirst {
+            delete("src/main/resources/static/docs")
+        }
+    }
 
-	register<Copy>("copyDocument") {
-		dependsOn(asciidoctor)
+    register<Copy>("copyDocument") {
+        dependsOn(asciidoctor)
 
-		destinationDir = file(".")
-		from(asciidoctor.get().outputDir) {
-			into("src/main/resources/static/docs")
-		}
-	}
+        destinationDir = file(".")
+        from(asciidoctor.get().outputDir) {
+            into("src/main/resources/static/docs")
+        }
+    }
 
-	bootJar {
-		dependsOn(asciidoctor)
+    bootJar {
+        dependsOn(asciidoctor)
 
-		from(asciidoctor.get().outputDir) {
-			into("BOOT-INF/classes/static/docs")
-		}
-	}
+        from(asciidoctor.get().outputDir) {
+            into("BOOT-INF/classes/static/docs")
+        }
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+
+    classDirectories.setFrom(
+            sourceSets.main.get().output.asFileTree.matching {
+                exclude("**/Web2ApplicationKt*")
+            }
+    )
+
+    finalizedBy("jacocoTestCoverageVerification")
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+val testCoverage by tasks.registering {
+    group = "verification"
+    description = "Runs the unit tests with coverage"
+
+    dependsOn(":test",
+            ":jacocoTestReport",
+            ":jacocoTestCoverageVerification")
+
+    tasks["jacocoTestReport"].mustRunAfter(tasks["test"])
+    tasks["jacocoTestCoverageVerification"].mustRunAfter(tasks["jacocoTestReport"])
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+  branches:
+    - develop
+    - feature/issue-4


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #4

## 🔖 작업 내용
- jacoco, codecov 적용하였습니다!

## 👀 추가 내용
- 로컬에서 `./gradlew build test` 실행 후, Build > reports > Jacobo > test > html > index.html 에서 확인하실 수 있습니다.
- branch 커버리지 80으로 일단 해두었는데 라인 커버리지 등등 논의해봐야할 것 같습니다! 뎁캠때 논의해보면 좋을 것 같아요.
- pr close 한 후 다시 pr 날리지 않고 reopen 해도 pull request에 적용되는 이벤트(codecov)가 다시 실행되네요 ?! 오늘 깨달았습니다..

## 📝 참고 자료
- [jacoco 적용](https://techblog.woowahan.com/2661/)
- [테스트 제외 파일 설정](https://stackoverflow.com/questions/62075448/jacoco-gradle-kotlin-dsl-exclude-file-from-violation-rules/72858353#72858353)
- [codecov docs](https://docs.codecov.com/docs/team-bot)
- [jacocoTestCoverageVerification Task 설정](https://velog.io/@lxxjn0/%EC%BD%94%EB%93%9C-%EB%B6%84%EC%84%9D-%EB%8F%84%EA%B5%AC-%EC%A0%81%EC%9A%A9%EA%B8%B0-2%ED%8E%B8-JaCoCo-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)