### PR TITLE
✨ Soft delete 적용

### DIFF
--- a/src/main/kotlin/com/yapp/web2/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/yapp/web2/common/entity/BaseEntity.kt
@@ -18,4 +18,8 @@ abstract class BaseEntity {
 
     @Enumerated(EnumType.STRING)
     var status: EntityStatus = EntityStatus.ACTIVE
+
+    fun softDelete() {
+        this.status = EntityStatus.INACTIVE
+    }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/comment/respository/CommentRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/respository/CommentRepository.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.comment.respository
+
+import com.yapp.web2.domain.comment.model.Comment
+import com.yapp.web2.domain.vote.model.Vote
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<Comment, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/comment/respository/ReplyCommentRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/respository/ReplyCommentRepository.kt
@@ -1,0 +1,6 @@
+package com.yapp.web2.domain.comment.respository
+
+import com.yapp.web2.domain.comment.model.ReplyComment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReplyCommentRepository : JpaRepository<ReplyComment, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/like/repository/CommentLikesRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/repository/CommentLikesRepository.kt
@@ -1,0 +1,6 @@
+package com.yapp.web2.domain.like.repository
+
+import com.yapp.web2.domain.like.model.CommentLikes
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentLikesRepository : JpaRepository<CommentLikes, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/like/repository/VoteLikesRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/repository/VoteLikesRepository.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.like.repository
+
+import com.yapp.web2.domain.like.model.VoteLikes
+import com.yapp.web2.domain.vote.model.Vote
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VoteLikesRepository : JpaRepository<VoteLikes, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/member/model/Member.kt
@@ -7,8 +7,10 @@ import com.yapp.web2.domain.vote.model.Vote
 import com.yapp.web2.domain.vote.model.option.VoteOption
 import com.yapp.web2.domain.vote.model.option.VoteOptionMember
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
+@Where(clause = "status = \'ACTIVE\'")
 class Member constructor(
     var nickname: String,
 

--- a/src/main/kotlin/com/yapp/web2/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/member/repository/MemberRepository.kt
@@ -1,0 +1,6 @@
+package com.yapp.web2.domain.member.repository
+
+import com.yapp.web2.domain.member.model.Member
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
@@ -5,8 +5,10 @@ import com.yapp.web2.domain.member.model.JobCategory
 import com.yapp.web2.domain.member.model.Member
 import com.yapp.web2.domain.vote.model.option.VoteOption
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
+@Where(clause = "status = \'ACTIVE\'")
 class Vote constructor(
     var title: String,
 

--- a/src/main/kotlin/com/yapp/web2/domain/vote/repository/HashTagRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/repository/HashTagRepository.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.vote.repository
+
+import com.yapp.web2.domain.vote.model.HashTag
+import com.yapp.web2.domain.vote.model.Vote
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface HashTagRepository : JpaRepository<HashTag, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/vote/repository/VoteRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/repository/VoteRepository.kt
@@ -1,0 +1,6 @@
+package com.yapp.web2.domain.vote.repository
+
+import com.yapp.web2.domain.vote.model.Vote
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VoteRepository : JpaRepository<Vote, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/vote/repository/option/VoteOptionMemberRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/repository/option/VoteOptionMemberRepository.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.vote.repository.option
+
+import com.yapp.web2.domain.vote.model.Vote
+import com.yapp.web2.domain.vote.model.option.VoteOptionMember
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VoteOptionMemberRepository : JpaRepository<VoteOptionMember, Long>

--- a/src/main/kotlin/com/yapp/web2/domain/vote/repository/option/VoteOptionRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/repository/option/VoteOptionRepository.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.vote.repository.option
+
+import com.yapp.web2.domain.vote.model.Vote
+import com.yapp.web2.domain.vote.model.option.VoteOption
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface VoteOptionRepository : JpaRepository<VoteOption, Long>

--- a/src/test/kotlin/com/yapp/web2/domain/vote/model/VoteTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/vote/model/VoteTest.kt
@@ -1,0 +1,43 @@
+package com.yapp.web2.domain.vote.model
+
+import com.yapp.web2.common.entity.EntityStatus
+import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.member.model.Member
+import com.yapp.web2.domain.member.repository.MemberRepository
+import com.yapp.web2.domain.vote.repository.VoteRepository
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+internal class VoteTest(
+    @Autowired val voteRepository: VoteRepository,
+    @Autowired val memberRepository: MemberRepository,
+) {
+    private lateinit var vote: Vote
+
+    @BeforeEach
+    fun beforeEach() {
+        val member = Member("MemberA", JobCategory.DEVELOPER, 3, null)
+        vote = Vote("VoteA", JobCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
+        memberRepository.save(member)
+        voteRepository.save(vote)
+    }
+
+    @Test
+    fun `소프트 딜리트된 엔티티는 조회되지 않는다`() {
+        vote.softDelete()
+        voteRepository.save(vote)
+
+        val votes = voteRepository.findAll()
+
+        assertThat(votes).hasSize(0)
+    }
+}


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #11 

## 🔖 작업 내용
- BaseEntity에 Soft delete 메서드 추가(`Status INACTIVE`로 업데이트)
- Soft delete 되지 않은 항목들만 조회 (`@Where()`)
- Repository 추가

## 👀 추가 내용
- `@Where(status = "ACTIVE")` 가 모든 Entity에 작성되는 중복이 발생합니다
- [Soft Delete 참고자료](https://velog.io/@max9106/JPA-soft-delete)
