### PR TITLE
♻️ FK 제거 및 Entity 세부 설정

### DIFF
--- a/src/main/kotlin/com/yapp/web2/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/yapp/web2/common/entity/BaseEntity.kt
@@ -10,13 +10,13 @@ import java.time.LocalDateTime
 @EntityListeners(value = [AuditingEntityListener::class])
 abstract class BaseEntity {
     @CreatedDate
-    @Column(updatable = false)
-    var createdAt: LocalDateTime = LocalDateTime.now()
+    val createdAt: LocalDateTime = LocalDateTime.now()
 
     @LastModifiedDate
     var modifiedAt: LocalDateTime = LocalDateTime.now()
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 8)
     var status: EntityStatus = EntityStatus.ACTIVE
 
     fun softDelete() {

--- a/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
@@ -8,13 +8,13 @@ import jakarta.persistence.*
 @Entity
 class Comment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val createdBy: Member,
 
     var contents: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vote_id")
+    @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
@@ -4,8 +4,10 @@ import com.yapp.web2.common.entity.BaseEntity
 import com.yapp.web2.domain.member.model.Member
 import com.yapp.web2.domain.vote.model.Vote
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
+@Where(clause = "status = \'ACTIVE\'")
 class Comment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -16,9 +18,13 @@ class Comment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
-) : BaseEntity() {
+
+    @OneToMany(mappedBy = "comment", cascade = [CascadeType.REMOVE], orphanRemoval = true)
+    val replyComments: List<ReplyComment> = mutableListOf(),
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) : BaseEntity() {
 }

--- a/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/model/Comment.kt
@@ -19,7 +19,7 @@ class Comment constructor(
     @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 
-    @OneToMany(mappedBy = "comment", cascade = [CascadeType.REMOVE], orphanRemoval = true)
+    @OneToMany(mappedBy = "comment")
     val replyComments: List<ReplyComment> = mutableListOf(),
 
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/comment/model/ReplyComment.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/model/ReplyComment.kt
@@ -3,8 +3,10 @@ package com.yapp.web2.domain.comment.model
 import com.yapp.web2.common.entity.BaseEntity
 import com.yapp.web2.domain.member.model.Member
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
+@Where(clause = "status = \'ACTIVE\'")
 class ReplyComment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -15,9 +17,11 @@ class ReplyComment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val comment: Comment,
-) : BaseEntity() {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reply_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) : BaseEntity() {
+
 }

--- a/src/main/kotlin/com/yapp/web2/domain/comment/model/ReplyComment.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/comment/model/ReplyComment.kt
@@ -7,13 +7,13 @@ import jakarta.persistence.*
 @Entity
 class ReplyComment constructor(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val createdBy: Member,
 
     var contents: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @JoinColumn(name = "comment_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val comment: Comment,
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/like/model/CommentLikes.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/model/CommentLikes.kt
@@ -7,11 +7,11 @@ import jakarta.persistence.*
 @Entity
 class CommentLikes constructor(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val likedBy: Member,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @JoinColumn(name = "comment_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val comment: Comment,
 ) {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/like/model/CommentLikes.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/model/CommentLikes.kt
@@ -13,9 +13,11 @@ class CommentLikes constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val comment: Comment,
-) {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_likes_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) {
+
 }

--- a/src/main/kotlin/com/yapp/web2/domain/like/model/VoteLikes.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/model/VoteLikes.kt
@@ -5,7 +5,7 @@ import com.yapp.web2.domain.vote.model.Vote
 import jakarta.persistence.*
 
 @Entity
-class VoteLikes(
+class VoteLikes constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val likedBy: Member,
@@ -13,9 +13,11 @@ class VoteLikes(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
-) {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_likes_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) {
+
 }

--- a/src/main/kotlin/com/yapp/web2/domain/like/model/VoteLikes.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/like/model/VoteLikes.kt
@@ -7,11 +7,11 @@ import jakarta.persistence.*
 @Entity
 class VoteLikes(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val likedBy: Member,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vote_id")
+    @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 ) {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/member/model/Member.kt
@@ -15,6 +15,7 @@ class Member constructor(
     var nickname: String,
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     var jobCategory: JobCategory,
 
     var workingYears: Int,
@@ -33,9 +34,10 @@ class Member constructor(
     @OneToMany(mappedBy = "votedBy")
     val voteOptions: MutableList<VoteOptionMember> = mutableListOf(),
 
-    ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) : BaseEntity() {
+
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/HashTag.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/HashTag.kt
@@ -3,15 +3,17 @@ package com.yapp.web2.domain.vote.model
 import jakarta.persistence.*
 
 @Entity
-class HashTag(
+@Table(indexes = [Index(name = "i_hash_tag", columnList = "hashTag")])
+class HashTag constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 
-    var hashTag: String
-) {
+    val hashTag: String,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hash_tag_id")
     val id: Long = 0L
+) {
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/HashTag.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/HashTag.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.*
 @Entity
 class HashTag(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vote_id")
+    @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 
     var hashTag: String

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
@@ -22,10 +22,10 @@ class Vote constructor(
     @Column(length = 30)
     var voteType: VoteType,
 
-    @OneToMany(mappedBy = "vote", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "vote")
     val voteOptions: MutableList<VoteOption> = mutableListOf(),
 
-    @OneToMany(mappedBy = "vote", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "vote")
     val hashTags: MutableList<HashTag> = mutableListOf(),
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
@@ -27,7 +27,7 @@ class Vote constructor(
     val hashTags: MutableList<HashTag> = mutableListOf(),
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val createdBy: Member,
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/Vote.kt
@@ -15,23 +15,26 @@ class Vote constructor(
     @Enumerated(EnumType.STRING)
     var jobCategory: JobCategory,
 
+    @Column(length = 1000)
     var contents: String,
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 30)
     var voteType: VoteType,
 
-    @OneToMany(mappedBy = "vote")
+    @OneToMany(mappedBy = "vote", cascade = [CascadeType.ALL])
     val voteOptions: MutableList<VoteOption> = mutableListOf(),
 
-    @OneToMany(mappedBy = "vote", cascade = [CascadeType.REMOVE])
+    @OneToMany(mappedBy = "vote", cascade = [CascadeType.ALL])
     val hashTags: MutableList<HashTag> = mutableListOf(),
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val createdBy: Member,
-) : BaseEntity() {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_id")
-    val id: Long = 0L
+    val id: Long = 0L,
+) : BaseEntity() {
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOption.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOption.kt
@@ -3,9 +3,11 @@ package com.yapp.web2.domain.vote.model.option
 import com.yapp.web2.common.entity.BaseEntity
 import com.yapp.web2.domain.vote.model.Vote
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
-class VoteOption(
+@Where(clause = "status = \'ACTIVE\'")
+class VoteOption constructor(
     val text: String?,
 
     val voteOptionImageFilename: String?,
@@ -15,9 +17,11 @@ class VoteOption(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
-) : BaseEntity() {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_option_id")
-    val id: Long? = null
+    val id: Long = 0L
+) : BaseEntity() {
+    //TODO text, image, codeblock이 모두 null인 경우에 대한 검증 메서드 필요
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOption.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOption.kt
@@ -13,7 +13,7 @@ class VoteOption(
     val codeBlock: String?,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vote_id")
+    @JoinColumn(name = "vote_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val vote: Vote,
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
@@ -18,6 +18,6 @@ class VoteOptionMember constructor(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_option_member_id")
-    private val id: Long = 0L,
+    val id: Long = 0L,
 ) {
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
@@ -2,9 +2,11 @@ package com.yapp.web2.domain.vote.model.option
 
 import com.yapp.web2.domain.member.model.Member
 import jakarta.persistence.*
+import org.hibernate.annotations.Where
 
 @Entity
-class VoteOptionMember(
+@Where(clause = "status = \'ACTIVE\'")
+class VoteOptionMember constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val votedBy: Member,
@@ -12,9 +14,10 @@ class VoteOptionMember(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_option_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val voteOption: VoteOption,
-) {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_option_member_id")
-    private val id: Long? = null
+    private val id: Long = 0L,
+) {
 }

--- a/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/vote/model/option/VoteOptionMember.kt
@@ -6,11 +6,11 @@ import jakarta.persistence.*
 @Entity
 class VoteOptionMember(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val votedBy: Member,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vote_option_id")
+    @JoinColumn(name = "vote_option_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val voteOption: VoteOption,
 ) {
     @Id


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #15 

## 🔖 작업 내용
- Entity 들의 FK 제약을 제거하였습니다. FK를 제거 하면 복잡도가 줄어들고, 테스트 코드 작성에 용이합니다. 특히, Update가 자주 일어나는 `Soft Delete`정책을 채택하였기에 FK 제거를 통한 성능 향상을 기대 할 수 있습니다. MySQL에서 제공하는 FK Indexing에 대해 추가 설정이 필요 할 수 있습니다.

- Entity 속성의 세부적인 명세를 적용했습니다. 길이 제한, 영속성 전이, `Soft Delete`적용 등
- 검색에 활용되는 `HashTag` Table에 인덱싱을 추가 했습니다. 

## 👀 추가 내용
[Foreign Key 없이 구축하는 관계형 데이터베이스 시스템에 대한 생각](https://engineering-skcc.github.io/oracle%20tuning/foreign_key_%EC%97%86%EC%9D%B4_%EA%B5%AC%EC%B6%95%ED%95%98%EB%8A%94_DB/)
[Foreign key를 제거하기로 했습니다](https://velog.io/@yrc97/JPA-Foreign-key%EB%A5%BC-%EC%A0%9C%EA%B1%B0%ED%95%98%EA%B8%B0%EB%A1%9C-%ED%96%88%EC%8A%B5%EB%8B%88%EB%8B%A4)

`HashTag` Table 설계 고민해볼 필요가 있을 거 같아요. 동일한 태그에 대해 여러 게시글이 생길 수 있어 동일한 해시태그 값을 가진 Row가 많아질 것 같습니다.

