### PR TITLE
✨ 메인 페이지 카테고리로 게시글 필터 API

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -15,14 +15,14 @@ endif::[]
 :toclevels: 5
 :sectlinks:
 
-=== 0. Check API
-==== link:actuator-health.html[1. Check Api Status]
+= 0. Check API
+=== link:actuator-health.html[1. Check Api Status]
 
-=== 1. Vote API
-==== link:get-popular-topic.html[1.1 인기 투표 게시글 조회]
-==== link:get-latest-topic-offset.html[1.2 최신 투표 게시글 조회]
-==== link:get-topic-detail.html[1.3 투표 게시글 상세 조회]
+= 1. Vote API
+=== link:get-popular-topic.html[1.1 인기 투표 게시글 조회]
+=== link:get-latest-topic-offset.html[1.2 최신 투표 게시글 조회]
+=== link:get-topic-detail.html[1.3 투표 게시글 상세 조회]
 
-=== 2. Comment API
-==== link:get-comments.html[2.1 투표 게시글 내 댓글 조회]
+= 2. Comment API
+=== link:get-comments.html[2.1 투표 게시글 내 댓글 조회]
 

--- a/src/docs/asciidoc/get-latest-topic-offset.adoc
+++ b/src/docs/asciidoc/get-latest-topic-offset.adoc
@@ -24,6 +24,12 @@ endif::[]
 // include::{snippets}/{docname}/curl-request.adoc[]
 === Http-Request
 include::{snippets}/{docname}/http-request.adoc[]
+[source,http,options="nowrap"]
+----
+GET /api/v1/topic/latest?lastOffset=16&category=CAREER HTTP/1.1
+Host: localhost:8080
+
+----
 // === Request-Headers
 // include::{snippets}/{docname}/request-headers.adoc[]
 === Request-Parameters
@@ -33,6 +39,22 @@ include::{snippets}/{docname}/http-request.adoc[]
 |`+lastOffset+`
 |마지막 투표 게시글 Id
 |true
+|`+topicCategory+`
+|투표 게시글 카테고리
+|true
+|===
+==== Topic Category
+|===
+|Parameter|Description
+
+|`+CAREER+`
+|커리어
+|`+DEVELOPER+`
+|개발
+|`+DESIGN+`
+|디자인
+|`+PRODUCT_MANAGER+`
+|기획
 |===
 
 == Response

--- a/src/main/kotlin/com/yapp/web2/domain/member/model/JobCategory.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/member/model/JobCategory.kt
@@ -1,7 +1,0 @@
-package com.yapp.web2.domain.member.model
-
-enum class JobCategory {
-	DESIGNER,
-	DEVELOPER,
-	PRODUCT_MANAGER,
-}

--- a/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
@@ -1,6 +1,7 @@
 package com.yapp.web2.domain.topic.application
 
 import com.yapp.web2.domain.topic.model.Topic
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.topic.repository.TopicQuerydslRepository
 import com.yapp.web2.web.api.error.BusinessException
 import com.yapp.web2.web.api.error.ErrorCode
@@ -31,8 +32,8 @@ class TopicService(
         }
     }
 
-    fun getLatestTopicsSlice(lastTopicId: Long?): Slice<TopicPreviewResponse> {
-        val latestTopicSliceVo = topicQuerydslRepository.findLatestTopicsByCategory(lastTopicId)
+    fun getLatestTopicsSlice(lastTopicId: Long?, topicCategory: TopicCategory): Slice<TopicPreviewResponse> {
+        val latestTopicSliceVo = topicQuerydslRepository.findLatestTopicsByCategory(lastTopicId, topicCategory)
 
         return SliceImpl(
             latestTopicSliceVo.topics.map { topicPreviewVo ->

--- a/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
@@ -32,7 +32,7 @@ class TopicService(
         }
     }
 
-    fun getLatestTopicsSlice(lastTopicId: Long?, topicCategory: TopicCategory): Slice<TopicPreviewResponse> {
+    fun getLatestTopicsSlice(lastTopicId: Long?, topicCategory: TopicCategory?): Slice<TopicPreviewResponse> {
         val latestTopicSliceVo = topicQuerydslRepository.findLatestTopicsByCategory(lastTopicId, topicCategory)
 
         return SliceImpl(

--- a/src/main/kotlin/com/yapp/web2/domain/topic/model/Topic.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/model/Topic.kt
@@ -3,7 +3,6 @@ package com.yapp.web2.domain.topic.model
 import com.yapp.web2.common.entity.BaseEntity
 import com.yapp.web2.domain.comment.model.Comment
 import com.yapp.web2.domain.like.model.TopicLikes
-import com.yapp.web2.domain.member.model.JobCategory
 import com.yapp.web2.domain.member.model.Member
 import com.yapp.web2.domain.topic.model.option.VoteOption
 import jakarta.persistence.*
@@ -15,7 +14,7 @@ class Topic constructor(
     var title: String,
 
     @Enumerated(EnumType.STRING)
-    var jobCategory: JobCategory,
+    var topicCategory: TopicCategory,
 
     @Column(length = 1000)
     var contents: String,

--- a/src/main/kotlin/com/yapp/web2/domain/topic/model/TopicCategory.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/model/TopicCategory.kt
@@ -1,0 +1,7 @@
+package com.yapp.web2.domain.topic.model
+
+enum class TopicCategory {
+	DESIGNER,
+	DEVELOPER,
+	PRODUCT_MANAGER,
+}

--- a/src/main/kotlin/com/yapp/web2/domain/topic/model/TopicCategory.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/model/TopicCategory.kt
@@ -4,4 +4,5 @@ enum class TopicCategory {
 	DESIGNER,
 	DEVELOPER,
 	PRODUCT_MANAGER,
+    CAREER,
 }

--- a/src/main/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepository.kt
@@ -7,9 +7,8 @@ import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.JPQLQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.web2.domain.comment.model.QComment.comment
-import com.yapp.web2.domain.like.model.QTopicLikes
 import com.yapp.web2.domain.like.model.QTopicLikes.*
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.model.QMember.member
 import com.yapp.web2.domain.topic.application.vo.LatestTopicSliceVo
 import com.yapp.web2.domain.topic.application.vo.TopicDetailVo
@@ -27,7 +26,7 @@ const val POPULAR_VOTE_SIZE = 4
 class TopicQuerydslRepository(
     private val queryFactory: JPAQueryFactory
 ) {
-    fun findLatestTopicsByCategory(lastTopicId: Long? = null, jobCategory: JobCategory? = null): LatestTopicSliceVo {
+    fun findLatestTopicsByCategory(lastTopicId: Long? = null, topicCategory: TopicCategory? = null): LatestTopicSliceVo {
         val results = queryFactory.select(
             Projections.constructor(
                 TopicPreviewVo::class.java,
@@ -39,7 +38,7 @@ class TopicQuerydslRepository(
             .from(topic)
             .where(
                 lastTopicId?.let { topic.id.lt(lastTopicId) },
-                jobCategory?.let { topic.jobCategory.eq(jobCategory) }
+                topicCategory?.let { topic.topicCategory.eq(topicCategory) }
             )
             .orderBy(topic.createdAt.desc())
             .limit((LATEST_VOTE_SLICE_SIZE + 1).toLong())

--- a/src/main/kotlin/com/yapp/web2/web/api/controller/topic/TopicController.kt
+++ b/src/main/kotlin/com/yapp/web2/web/api/controller/topic/TopicController.kt
@@ -1,6 +1,7 @@
 package com.yapp.web2.web.api.controller.topic
 
 import com.yapp.web2.domain.topic.application.TopicService
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.web.api.response.ApiResponse
 import com.yapp.web2.web.dto.topic.response.TopicDetailResponse
 import com.yapp.web2.web.dto.topic.response.TopicPreviewResponse
@@ -20,8 +21,8 @@ class TopicController(
     }
 
     @GetMapping("/latest")
-    fun getTopicsSlice(@RequestParam lastOffset: String?): ApiResponse<List<TopicPreviewResponse>> {
-        val latestTopicsSlice = topicService.getLatestTopicsSlice(lastOffset?.toLong()) //TODO toLong() 예외처리
+    fun getTopicsSlice(@RequestParam lastOffset: String?, @RequestParam topicCategory: TopicCategory): ApiResponse<List<TopicPreviewResponse>> {
+        val latestTopicsSlice = topicService.getLatestTopicsSlice(lastOffset?.toLong(), topicCategory) //TODO toLong() 예외처리
 
         return ApiResponse.success(latestTopicsSlice)
     }

--- a/src/main/kotlin/com/yapp/web2/web/api/controller/topic/TopicController.kt
+++ b/src/main/kotlin/com/yapp/web2/web/api/controller/topic/TopicController.kt
@@ -21,7 +21,7 @@ class TopicController(
     }
 
     @GetMapping("/latest")
-    fun getTopicsSlice(@RequestParam lastOffset: String?, @RequestParam topicCategory: TopicCategory): ApiResponse<List<TopicPreviewResponse>> {
+    fun getTopicsSlice(@RequestParam lastOffset: String?, @RequestParam topicCategory: TopicCategory?): ApiResponse<List<TopicPreviewResponse>> {
         val latestTopicsSlice = topicService.getLatestTopicsSlice(lastOffset?.toLong(), topicCategory) //TODO toLong() 예외처리
 
         return ApiResponse.success(latestTopicsSlice)

--- a/src/main/kotlin/com/yapp/web2/web/dto/comment/response/CommentDetailResponse.kt
+++ b/src/main/kotlin/com/yapp/web2/web/dto/comment/response/CommentDetailResponse.kt
@@ -2,7 +2,6 @@ package com.yapp.web2.web.dto.comment.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.yapp.web2.domain.comment.model.Comment
-import com.yapp.web2.domain.member.model.JobCategory
 import com.yapp.web2.web.api.response.OffsetIdSupport
 import com.yapp.web2.web.dto.member.response.MemberResponse
 

--- a/src/test/kotlin/com/yapp/web2/domain/comment/application/CommentServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/comment/application/CommentServiceTest.kt
@@ -4,7 +4,7 @@ import com.yapp.web2.common.EntityFactory
 import com.yapp.web2.domain.comment.model.Comment
 import com.yapp.web2.domain.comment.respository.CommentRepository
 import com.yapp.web2.domain.like.model.CommentLikes
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -55,7 +55,7 @@ internal class CommentServiceTest @Autowired constructor(
         )
 
         val topic = topicRepository.save(
-            Topic("VoteA", JobCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
+            Topic("VoteA", TopicCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
         )
 
         val sampleComments: MutableList<Comment> = mutableListOf()

--- a/src/test/kotlin/com/yapp/web2/domain/comment/respository/CommentQuerydslRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/comment/respository/CommentQuerydslRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.yapp.web2.domain.comment.respository
 import com.yapp.web2.common.EntityFactory
 import com.yapp.web2.domain.comment.model.Comment
 import com.yapp.web2.domain.like.model.CommentLikes
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -66,7 +66,7 @@ internal class CommentQuerydslRepositoryTest @Autowired constructor(
         )
 
         val topic = topicRepository.save(
-            Topic("VoteA", JobCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
+            Topic("VoteA", TopicCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
         )
 
         val sampleComments: MutableList<Comment> = mutableListOf()

--- a/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
@@ -1,7 +1,7 @@
 package com.yapp.web2.domain.topic.application
 
 import com.yapp.web2.common.EntityFactory
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -96,7 +96,7 @@ internal class TopicServiceTest @Autowired constructor(
         // 투표 게시글 생성
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         // 투표 게시글 마다 2개의 옵션이 존재
@@ -123,7 +123,7 @@ internal class TopicServiceTest @Autowired constructor(
 
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         for (vote in sampleTopics) {

--- a/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
@@ -36,7 +36,7 @@ internal class TopicServiceTest @Autowired constructor(
         saveDummyTopicsDetail(2)
 
         //when
-        val latestTopicsSlice = topicService.getLatestTopicsSlice(null).content
+        val latestTopicsSlice = topicService.getLatestTopicsSlice(null, null).content
 
         //then
         assertThat(latestTopicsSlice).hasSize(2)
@@ -46,6 +46,24 @@ internal class TopicServiceTest @Autowired constructor(
 
         assertThat(voteOptionPreview.voteOptions[0].votedAmount).isEqualTo(2)
         assertThat(voteOptionPreview.voteOptions[1].votedAmount).isEqualTo(1)
+    }
+
+    @Test
+    fun `최신순 페이지 조회 카테고리 필터 테스트`() {
+        //given
+        val topics = saveDummyTopicsDetail(2)
+        val createdBy = topics[0].createdBy
+        topicRepository.saveAll(listOf(
+            Topic("Topic CareerA", TopicCategory.CAREER, "Content CareerA", VoteType.TEXT, createdBy = createdBy),
+            Topic("Topic CareerB", TopicCategory.CAREER, "Content CareerB", VoteType.TEXT, createdBy = createdBy),
+            Topic("Topic CareerC", TopicCategory.CAREER, "Content CareerC", VoteType.TEXT, createdBy = createdBy),
+        ))
+
+        //when
+        val latestTopicsSlice = topicService.getLatestTopicsSlice(null, TopicCategory.CAREER).content
+
+        //then
+        assertThat(latestTopicsSlice).hasSize(3)
     }
 
     @Test

--- a/src/test/kotlin/com/yapp/web2/domain/topic/model/TopicTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/model/TopicTest.kt
@@ -1,7 +1,6 @@
 package com.yapp.web2.domain.topic.model
 
 import com.yapp.web2.common.EntityFactory
-import com.yapp.web2.domain.member.model.JobCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.repository.TopicRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +24,7 @@ internal class TopicTest(
         topicRepository.deleteAll()
 
         val member = EntityFactory.testMemberA()
-        topic = Topic("VoteA", JobCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
+        topic = Topic("VoteA", TopicCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member)
 
         memberRepository.save(member)
         topicRepository.save(topic)

--- a/src/test/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.yapp.web2.domain.topic.repository
 
 import com.yapp.web2.common.EntityFactory
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -84,13 +84,13 @@ internal class TopicQuerydslRepositoryTest @Autowired constructor(
         memberRepository.save(memberB)
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..3) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DESIGNER, "Content$i", VoteType.TEXT, createdBy = memberB))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DESIGNER, "Content$i", VoteType.TEXT, createdBy = memberB))
         }
         topicRepository.saveAll(sampleTopics) // JobCategory == DESIGNER 인 게시글 3개 저장
 
         //when
         //우선순위(최신순)으로 정렬된 데이터에서, id가 lastTopicId 이후에서 부터 조회
-        val searchBySlice = topicQuerydslRepository.findLatestTopicsByCategory(jobCategory = JobCategory.DEVELOPER)
+        val searchBySlice = topicQuerydslRepository.findLatestTopicsByCategory(topicCategory = TopicCategory.DEVELOPER)
 
         //then
         val content = searchBySlice.topics
@@ -155,7 +155,7 @@ internal class TopicQuerydslRepositoryTest @Autowired constructor(
         memberRepository.save(memberA)
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         return topicRepository.saveAll(sampleTopics)
@@ -167,7 +167,7 @@ internal class TopicQuerydslRepositoryTest @Autowired constructor(
 
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         for (topic in sampleTopics) {

--- a/src/test/kotlin/com/yapp/web2/domain/vote/repository/VoteQuerydslRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/vote/repository/VoteQuerydslRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.yapp.web2.domain.vote.repository
 
 import com.yapp.web2.common.EntityFactory
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -86,13 +86,13 @@ internal class VoteQuerydslRepositoryTest @Autowired constructor(
         memberRepository.save(memberB)
         val sampleVotes: MutableList<Topic> = mutableListOf()
         for (i in 1..3) {
-            sampleVotes.add(Topic("Vote$i", JobCategory.DESIGNER, "Content$i", VoteType.TEXT, createdBy = memberB))
+            sampleVotes.add(Topic("Vote$i", TopicCategory.DESIGNER, "Content$i", VoteType.TEXT, createdBy = memberB))
         }
         topicRepository.saveAll(sampleVotes) // JobCategory == DESIGNER 인 게시글 3개 저장
 
         //when
         //우선순위(최신순)으로 정렬된 데이터에서, id가 lastVoteId 이후에서 부터 조회
-        val searchBySlice = topicQuerydslRepository.findLatestTopicsByCategory(jobCategory = JobCategory.DEVELOPER)
+        val searchBySlice = topicQuerydslRepository.findLatestTopicsByCategory(topicCategory = TopicCategory.DEVELOPER)
 
         //then
         val content = searchBySlice.topics
@@ -157,7 +157,7 @@ internal class VoteQuerydslRepositoryTest @Autowired constructor(
         memberRepository.save(member)
         val sampleVotes: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleVotes.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = member))
+            sampleVotes.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = member))
         }
 
         return topicRepository.saveAll(sampleVotes)
@@ -169,7 +169,7 @@ internal class VoteQuerydslRepositoryTest @Autowired constructor(
 
         val sampleVotes: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleVotes.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleVotes.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         for (vote in sampleVotes) {

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/CommonDocumentationTests.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/CommonDocumentationTests.kt
@@ -12,7 +12,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 /**
  * 공통 응답 Spring rest docs snippet 생성용 테스트
  */
-internal class TopicControllerTest : ApiControllerTest(uri = "/api/v1/topic") {
+internal class CommonDocumentationTests : ApiControllerTest(uri = "/api/v1/topic") {
 
     // 일반적인 공통응답인 경우
     @Test

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/comment/CommentControllerTest.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/comment/CommentControllerTest.kt
@@ -4,8 +4,7 @@ import com.yapp.web2.common.EntityFactory
 import com.yapp.web2.domain.comment.model.Comment
 import com.yapp.web2.domain.comment.respository.CommentRepository
 import com.yapp.web2.domain.like.model.CommentLikes
-import com.yapp.web2.domain.member.model.JobCategory
-import com.yapp.web2.domain.member.model.Member
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -99,7 +98,7 @@ internal class CommentControllerTest @Autowired constructor(
         )
 
         val topic = topicRepository.save(
-            Topic("VoteA", JobCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member[0])
+            Topic("VoteA", TopicCategory.DEVELOPER, "ContentA", VoteType.TEXT, createdBy = member[0])
         )
 
         val sampleComments: MutableList<Comment> = mutableListOf()

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/topic/TopicControllerTest.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/topic/TopicControllerTest.kt
@@ -1,7 +1,7 @@
 package com.yapp.web2.web.api.controller.topic
 
 import com.yapp.web2.common.EntityFactory
-import com.yapp.web2.domain.member.model.JobCategory
+import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.VoteType
@@ -216,7 +216,7 @@ internal class TopicControllerTest @Autowired constructor(
 
         val sampleTopics: MutableList<Topic> = mutableListOf()
         for (i in 1..amount) {
-            sampleTopics.add(Topic("Vote$i", JobCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
+            sampleTopics.add(Topic("Vote$i", TopicCategory.DEVELOPER, "Content$i", VoteType.TEXT, createdBy = memberA))
         }
 
         for (topic in sampleTopics) {


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #26 

## 🔖 작업 내용
- 투표 게시글 조회시, 투표 게시글의 카테고리에 따른 필터링 조회 기능 추가
- Rest docs에 Category 내용 추가

## 👀 추가 내용
- [Jpa Converter](https://velog.io/@stpn94/JPA-Converter)를 통해 String 타입으로 저장된 Category를 DB테이블에 저장, 조회시 `Integer` 타입 같은 코드로 변환하여 성능향상을 기대할 수 있다고 합니다. 추후 개선사항으로 정리해두겠습니다.
