### PR TITLE
✨ member 조회 api 

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -35,3 +35,6 @@ endif::[]
 === link:signup.html[3.1 회원가입]
 === link:signin.html[3.2 로그인]
 === link:post-nickname-duplication.html[3.3 닉네임 중복 확인]
+
+= 4. Member API
+=== link:get-member.html[4.1 회원정보 조회]

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -32,6 +32,8 @@ endif::[]
 === link:get-comments.html[2.1 투표 게시글 내 댓글 조회]
 
 = 3. Auth API
+auth 관련 api (탈퇴, refresh, 로그아웃)는 노션 참고 link:https://www.notion.so/yapp-workspace/API-b4d5aa9b272d42c199161f0910472f77[notion 바로가기]
+
 === link:signup.html[3.1 회원가입]
 === link:signin.html[3.2 로그인]
 === link:post-nickname-duplication.html[3.3 닉네임 중복 확인]

--- a/src/docs/asciidoc/get-member.adoc
+++ b/src/docs/asciidoc/get-member.adoc
@@ -1,0 +1,32 @@
+ifndef::snippets[]
+:snippets: build/generated-snippets
+endif::[]
+= {docname} API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+== Request
+=== Http-Request
+include::{snippets}/{docname}/http-request.adoc[]
+
+==== description
+memberId 없이 /api/v1/member 로 요청회다면 현재 로그인한 유저 정보 가져옴
+
+=== Request-Headers
+include::{snippets}/{docname}/request-headers.adoc[]
+
+== Response
+=== Http-Response
+include::{snippets}/{docname}/http-response.adoc[]
+=== Response-Fields
+==== Common
+include::{snippets}/common/response-fields.adoc[]
+
+==== Data
+include::{snippets}/{docname}/response-fields-data.adoc[]
+
+link:api-docs.html[back to api-docs]

--- a/src/docs/asciidoc/get-member.adoc
+++ b/src/docs/asciidoc/get-member.adoc
@@ -13,8 +13,11 @@ endif::[]
 === Http-Request
 include::{snippets}/{docname}/http-request.adoc[]
 
-==== description
-memberId 없이 /api/v1/member 로 요청회다면 현재 로그인한 유저 정보 가져옴
+=== description
+memberId 없이 /api/v1/member 로 요청한다면 현재 로그인한 유저 정보 가져옴
+
+- 나의 정보 조회: /api/v1/member
+- 다른 사람 정보 조회: /api/v1/member/{memberId}
 
 === Request-Headers
 include::{snippets}/{docname}/request-headers.adoc[]

--- a/src/main/kotlin/com/yapp/web2/domain/member/application/MemberService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/member/application/MemberService.kt
@@ -1,9 +1,11 @@
 package com.yapp.web2.domain.member.application
 
+import com.yapp.web2.common.util.findByIdOrThrow
 import com.yapp.web2.domain.member.repository.MemberRepository
 import com.yapp.web2.web.api.error.BusinessException
 import com.yapp.web2.web.api.error.ErrorCode
 import com.yapp.web2.web.dto.member.request.NicknameDuplicationRequest
+import com.yapp.web2.web.dto.member.response.MemberResponse
 import com.yapp.web2.web.dto.member.response.NicknameDuplicationResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,6 +26,8 @@ class MemberService(
     fun isValid(nickname: String): Boolean {
         return nickname.length <= NICKNAME_MAX_LENGTH
     }
+
+    fun getMember(memberId: Long) = MemberResponse.of(memberRepository.findByIdOrThrow(memberId))
 
     companion object {
         const val NICKNAME_MAX_LENGTH = 20

--- a/src/main/kotlin/com/yapp/web2/web/api/controller/member/MemberController.kt
+++ b/src/main/kotlin/com/yapp/web2/web/api/controller/member/MemberController.kt
@@ -1,13 +1,12 @@
 package com.yapp.web2.web.api.controller.member
 
+import com.yapp.web2.common.annotation.CurrentMember
 import com.yapp.web2.domain.member.application.MemberService
+import com.yapp.web2.domain.member.model.Member
 import com.yapp.web2.web.api.response.ApiResponse
 import com.yapp.web2.web.dto.member.request.NicknameDuplicationRequest
 import com.yapp.web2.web.dto.member.response.NicknameDuplicationResponse
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1")
@@ -18,4 +17,15 @@ class MemberController(
     fun existsNickname(@RequestBody nicknameDuplicationRequest: NicknameDuplicationRequest): ApiResponse<NicknameDuplicationResponse> {
         return ApiResponse.success(memberService.existsByNickname(nicknameDuplicationRequest))
     }
+
+    @GetMapping("/member/{memberId}", "/member")
+    fun getMember(
+        @CurrentMember member: Member,
+        @PathVariable(required = false, name = "memberId") memberId: Long?
+    ) =
+        ApiResponse.success(
+            memberId?.let {
+                memberService.getMember(memberId)
+            } ?: memberService.getMember(member.id)
+        )
 }

--- a/src/main/kotlin/com/yapp/web2/web/dto/member/response/MemberResponse.kt
+++ b/src/main/kotlin/com/yapp/web2/web/dto/member/response/MemberResponse.kt
@@ -7,7 +7,7 @@ data class MemberResponse(
     val nickname: String,
     val profileImage: String?,
     val jobCategory: String,
-    val workingYears: Int,
+    val workingYears: String,
 ) {
 
     companion object {
@@ -17,8 +17,14 @@ data class MemberResponse(
                 member.nickname,
                 member.profileImage,
                 member.jobCategory,
-                member.workingYears,
+                this.convertIntToString(member.workingYears),
             )
+        }
+
+        private fun convertIntToString(years: Int) = when (years) {
+            0 -> "1년 미만"
+            in 1..9 -> "${years}년차"
+            else -> "10년 이상"
         }
     }
 }

--- a/src/test/kotlin/com/yapp/web2/common/config/SecurityConfig.kt
+++ b/src/test/kotlin/com/yapp/web2/common/config/SecurityConfig.kt
@@ -29,6 +29,7 @@ class SecurityConfig(
                 "/api/v1/auth/**",
                 "/api/v1/topic/**",
                 "/api/v1/comment/**",
+                "/api/v1/member/**",
                 "/docs/**",
                 "/api/v1/nickname-duplication",
                 "/api/v1/vote/option"

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/member/MemberControllerTest.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/member/MemberControllerTest.kt
@@ -1,26 +1,38 @@
 package com.yapp.web2.web.api.controller.member
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.yapp.web2.common.EntityFactory
+import com.yapp.web2.common.TestMember
+import com.yapp.web2.domain.member.application.MemberService
 import com.yapp.web2.web.api.controller.ApiControllerTest
 import com.yapp.web2.web.dto.member.request.NicknameDuplicationRequest
+import com.yapp.web2.web.dto.member.response.MemberResponse
+import com.yapp.web2.web.dto.member.response.NicknameDuplicationResponse
+import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.http.MediaType
+import org.springframework.restdocs.headers.HeaderDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal class MemberControllerTest(
+internal class MemberControllerTest : ApiControllerTest(uri = "/api/v1") {
 
-) : ApiControllerTest(uri = "/api/v1") {
+    @MockkBean
+    lateinit var memberService: MemberService
+
     @Test
     fun `닉네임 중복 확인 API`() {
         val nicknameDuplicationRequest = NicknameDuplicationRequest("leah")
+        every { memberService.existsByNickname(any()) }.returns(NicknameDuplicationResponse(false))
 
         val uri = "$uri/nickname-duplication"
         mockMvc.perform(
@@ -43,6 +55,48 @@ internal class MemberControllerTest(
                 )
             )
     }
+
+    @Test
+    @TestMember
+    fun `유저 정보 조회 API`() {
+        val memberId = 1L
+        val uri = "$uri/member/{memberId}"
+
+        every { memberService.getMember(any()) }.returns(MemberResponse.of(EntityFactory.testMemberA()))
+
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get(uri, memberId)
+                .header("Authorization", "accesstoken")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("SUCCESS"))
+            .andDo(MockMvcResultHandlers.print())
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "get-member", // docs directory name
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    HeaderDocumentation.requestHeaders(
+                        HeaderDocumentation.headerWithName("Authorization").description("회원 AccessToken")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.beneathPath("data").withSubsectionId("data"),
+                        *memberDataResponseFieldsSnippet(),
+                    )
+                )
+            )
+    }
+
+    private fun memberDataResponseFieldsSnippet(): Array<FieldDescriptor> {
+        return arrayOf(
+            PayloadDocumentation.fieldWithPath("memberId").description("작성자 Id"),
+            PayloadDocumentation.fieldWithPath("nickname").description("작성자 닉네임"),
+            PayloadDocumentation.fieldWithPath("profileImage").type(JsonFieldType.STRING).description("작성자 프로필 이미지").optional(),
+            PayloadDocumentation.fieldWithPath("jobCategory").description("작성자 직군"),
+            PayloadDocumentation.fieldWithPath("workingYears").description("작성자 연차"),
+        )
+    }
+
 
     private fun nicknameDuplicationDataResponseFieldsSnippet(): Array<FieldDescriptor> {
         return arrayOf(


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #61

## 🔖 작업 내용
- memberId 보내면 다른 유저 조회, memberId null로 보낸다면 현재 로그인한 유저 조회 

## 👀 추가 내용
- memberResponse에 연차 String으로 반환하도록 하였습니다! 
