### PR TITLE
♻️ 코드블럭/언어 분리하여 저장

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
@@ -104,6 +104,7 @@ class TopicService(
             val voteOption = VoteOption(
                 voteOptionDto.text?: nullValueException(),
                 voteOptionDto.image,
+                voteOptionDto.language,
                 voteOptionDto.codeBlock,
                 topic
             )

--- a/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/application/TopicService.kt
@@ -4,6 +4,7 @@ import com.yapp.web2.common.util.findByIdOrThrow
 import com.yapp.web2.domain.like.model.TopicLikes
 import com.yapp.web2.domain.like.repository.TopicLikesRepository
 import com.yapp.web2.domain.member.model.Member
+import com.yapp.web2.domain.topic.model.HashTag
 import com.yapp.web2.domain.topic.model.Topic
 import com.yapp.web2.domain.topic.model.TopicCategory
 import com.yapp.web2.domain.topic.model.VoteType
@@ -99,6 +100,8 @@ class TopicService(
             voteType,
             createdBy = member,
         )
+
+        requestDto.tags?.map { tag -> topic.addTags(HashTag(topic, tag)) }
 
         for (voteOptionDto in requestDto.voteOptions) {
             val voteOption = VoteOption(

--- a/src/main/kotlin/com/yapp/web2/domain/topic/model/Topic.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/model/Topic.kt
@@ -26,7 +26,7 @@ class Topic constructor(
     @OneToMany(mappedBy = "topic", cascade = [CascadeType.PERSIST])
     val voteOptions: MutableList<VoteOption> = mutableListOf(),
 
-    @OneToMany(mappedBy = "topic")
+    @OneToMany(mappedBy = "topic", cascade = [CascadeType.PERSIST])
     val hashTags: MutableList<HashTag> = mutableListOf(),
 
     @OneToMany(mappedBy = "topic")
@@ -51,5 +51,9 @@ class Topic constructor(
 
     fun addTopicLike(topicLikes: TopicLikes) {
         this.topicLikes.add(topicLikes)
+    }
+
+    fun addTags(hashTag: HashTag) {
+        this.hashTags.add(hashTag)
     }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/topic/model/option/VoteOption.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/topic/model/option/VoteOption.kt
@@ -12,6 +12,7 @@ class VoteOption constructor(
 
     val image: String?,
 
+    val language: String?,
     val codeBlock: String?,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/yapp/web2/web/dto/topic/response/TopicDetailResponse.kt
+++ b/src/main/kotlin/com/yapp/web2/web/dto/topic/response/TopicDetailResponse.kt
@@ -30,7 +30,7 @@ data class TopicDetailResponse(
                 voteAmount,
                 liked,
                 likedAmount,
-                topic.hashTags.map { it.toString() },
+                topic.hashTags.map { it.hashTag },
                 voteOptionPreviewResponse,
             )
         }

--- a/src/main/kotlin/com/yapp/web2/web/dto/voteoption/request/VoteOptionPostRequest.kt
+++ b/src/main/kotlin/com/yapp/web2/web/dto/voteoption/request/VoteOptionPostRequest.kt
@@ -3,5 +3,6 @@ package com.yapp.web2.web.dto.voteoption.request
 data class VoteOptionPostRequest(
     val text: String?,
     val image: String?,
+    val language: String?,
     val codeBlock: String?,
 )

--- a/src/main/kotlin/com/yapp/web2/web/dto/voteoption/response/VoteOptionPreviewResponse.kt
+++ b/src/main/kotlin/com/yapp/web2/web/dto/voteoption/response/VoteOptionPreviewResponse.kt
@@ -6,6 +6,7 @@ data class VoteOptionPreviewResponse(
     val voteOptionId: Long,
     val text: String?,
     val image: String?,
+    val language: String?,
     val codeBlock: String?,
     val voted: Boolean,
     val voteAmount: Int,
@@ -17,6 +18,7 @@ data class VoteOptionPreviewResponse(
                 voteOption.id,
                 voteOption.text,
                 voteOption.image,
+                voteOption.language,
                 voteOption.codeBlock,
                 voted,
                 voteOption.voteOptionMembers.size

--- a/src/test/kotlin/com/yapp/web2/common/EntityFactory.kt
+++ b/src/test/kotlin/com/yapp/web2/common/EntityFactory.kt
@@ -38,8 +38,8 @@ class EntityFactory {
                 createdBy = createdBy,
             )
 
-            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, topic))
-            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, null, topic))
 
             return topic
         }

--- a/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 internal class TopicServiceTest @Autowired constructor(
@@ -107,6 +108,7 @@ internal class TopicServiceTest @Autowired constructor(
             .isInstanceOf(BusinessException::class.java)
     }
 
+    @Transactional
     @Test
     fun `투표 게시글 저장 테스트`() {
         //given
@@ -130,6 +132,7 @@ internal class TopicServiceTest @Autowired constructor(
         val findOne = topicRepository.findAll()[0]
         assertThat(findOne.title).isEqualTo("TopicA")
         assertThat(findOne.voteType).isEqualTo(VoteType.TEXT)
+        assertThat(findOne.hashTags[0].hashTag).isEqualTo("tagA")
     }
 
     @Test

--- a/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/application/TopicServiceTest.kt
@@ -116,8 +116,8 @@ internal class TopicServiceTest @Autowired constructor(
             "TopicA",
             "Contents A",
             listOf(
-                VoteOptionPostRequest("OptionA", null, null),
-                VoteOptionPostRequest("OptionB", null, null),
+                VoteOptionPostRequest("OptionA", null, null, null),
+                VoteOptionPostRequest("OptionB", null, null, null),
             ),
             TopicCategory.DEVELOPER,
             listOf("tagA", "tagB")
@@ -141,8 +141,8 @@ internal class TopicServiceTest @Autowired constructor(
             null, // 예외 케이스
             "Contents A",
             listOf(
-                VoteOptionPostRequest("OptionA", null, null),
-                VoteOptionPostRequest("OptionB", null, null),
+                VoteOptionPostRequest("OptionA", null, null, null),
+                VoteOptionPostRequest("OptionB", null, null, null),
             ),
             TopicCategory.DEVELOPER,
             listOf("tagA", "tagB")
@@ -203,8 +203,8 @@ internal class TopicServiceTest @Autowired constructor(
         // 투표 게시글 마다 2개의 옵션이 존재
         // 첫번째 옵션에 2개, 두번째 옵션에 1개가 투표됨
         for (vote in sampleTopics) {
-            val voteOptionA = VoteOption("${vote.contents} OptionA", null, null, vote)
-            val voteOptionB = VoteOption("${vote.contents} OptionB", null, null, vote)
+            val voteOptionA = VoteOption("${vote.contents} OptionA", null, null, null, vote)
+            val voteOptionB = VoteOption("${vote.contents} OptionB", null, null, null, vote)
 
             vote.addVoteOption(voteOptionA)
             vote.addVoteOption(voteOptionB)
@@ -228,8 +228,8 @@ internal class TopicServiceTest @Autowired constructor(
         }
 
         for (vote in sampleTopics) {
-            vote.addVoteOption(VoteOption("${vote.contents} OptionA", null, null, vote))
-            vote.addVoteOption(VoteOption("${vote.contents} OptionB", null, null, vote))
+            vote.addVoteOption(VoteOption("${vote.contents} OptionA", null, null, null, vote))
+            vote.addVoteOption(VoteOption("${vote.contents} OptionB", null, null, null, vote))
         }
 
         // 투표 게시글 크기의 2배 만큼 투표수를 받음

--- a/src/test/kotlin/com/yapp/web2/domain/topic/model/VoteTypeTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/model/VoteTypeTest.kt
@@ -9,10 +9,10 @@ internal class VoteTypeTest {
     @Test
     fun `저장 요청에 따라 옳바른 투표 타입 생성 테스트`() {
         //given
-        val voteOptionAll = VoteOptionPostRequest("Text", "imageUrl", "codeBlock")
-        val voteOptionCode = VoteOptionPostRequest("Text", null, "codeBlock")
-        val voteOptionImage = VoteOptionPostRequest("Text", "imageUrl", null)
-        val voteOptionText = VoteOptionPostRequest("Text", null, null)
+        val voteOptionAll = VoteOptionPostRequest("Text", "imageUrl",null, "codeBlock")
+        val voteOptionCode = VoteOptionPostRequest("Text", null,null, "codeBlock")
+        val voteOptionImage = VoteOptionPostRequest("Text", "imageUrl",null, null)
+        val voteOptionText = VoteOptionPostRequest("Text", null,null, null)
 
         //when
         assertAll(

--- a/src/test/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/topic/repository/TopicQuerydslRepositoryTest.kt
@@ -171,8 +171,8 @@ internal class TopicQuerydslRepositoryTest @Autowired constructor(
         }
 
         for (topic in sampleTopics) {
-            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, topic))
-            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, null, topic))
         }
 
         // 투표 게시글 크기의 2배 만큼 투표수를 받음

--- a/src/test/kotlin/com/yapp/web2/domain/vote/repository/VoteQuerydslRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/vote/repository/VoteQuerydslRepositoryTest.kt
@@ -173,8 +173,8 @@ internal class VoteQuerydslRepositoryTest @Autowired constructor(
         }
 
         for (vote in sampleVotes) {
-            vote.addVoteOption(VoteOption("${vote.contents} OptionA", null, null, vote))
-            vote.addVoteOption(VoteOption("${vote.contents} OptionB", null, null, vote))
+            vote.addVoteOption(VoteOption("${vote.contents} OptionA", null, null, null, vote))
+            vote.addVoteOption(VoteOption("${vote.contents} OptionB", null, null, null, vote))
         }
 
         // 투표 게시글 크기의 2배 만큼 투표수를 받음

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/topic/MockTopicControllerTest.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/topic/MockTopicControllerTest.kt
@@ -40,8 +40,8 @@ class MockTopicControllerTest : ApiControllerTest(uri = "/api/v1/topic") {
             "TopicA",
             "Contents A",
             listOf(
-                VoteOptionPostRequest("OptionA", null, null),
-                VoteOptionPostRequest("OptionB", null, null),
+                VoteOptionPostRequest("OptionA", null, null, null),
+                VoteOptionPostRequest("OptionB", null, null, null),
             ),
             TopicCategory.DEVELOPER,
             listOf("tagA", "tagB")

--- a/src/test/kotlin/com/yapp/web2/web/api/controller/topic/TopicControllerTest.kt
+++ b/src/test/kotlin/com/yapp/web2/web/api/controller/topic/TopicControllerTest.kt
@@ -181,8 +181,8 @@ internal class TopicControllerTest @Autowired constructor(
             Topic("Topic CareerC", TopicCategory.CAREER, "Content CareerC", VoteType.TEXT, createdBy = createdBy),
         )
         for (topic in topics) {
-            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, topic))
-            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, null, topic))
         }
 
         topicRepository.saveAll(topics)
@@ -219,8 +219,8 @@ internal class TopicControllerTest @Autowired constructor(
             "TopicA",
             "Contents A",
             listOf(
-                VoteOptionPostRequest("OptionA", null, null),
-                VoteOptionPostRequest("OptionB", null, null),
+                VoteOptionPostRequest("OptionA", null, null, null),
+                VoteOptionPostRequest("OptionB", null, null, null),
             ),
             TopicCategory.DEVELOPER,
             listOf("tagA", "tagB")
@@ -261,8 +261,8 @@ internal class TopicControllerTest @Autowired constructor(
             null,
             "Contents A",
             listOf(
-                VoteOptionPostRequest(null, null, null),
-                VoteOptionPostRequest("OptionB", null, null),
+                VoteOptionPostRequest(null, null, null, null),
+                VoteOptionPostRequest("OptionB", null, null, null),
             ),
             TopicCategory.DEVELOPER,
             listOf("tagA", "tagB")
@@ -420,8 +420,8 @@ internal class TopicControllerTest @Autowired constructor(
         }
 
         for (topic in sampleTopics) {
-            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, topic))
-            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionA", null, null, null, topic))
+            topic.addVoteOption(VoteOption("${topic.contents} OptionB", null, null, null, topic))
         }
 
         // 투표 게시글 크기의 2배 만큼 투표수를 받음


### PR DESCRIPTION
## 🔗 이슈 번호
- resolved #58 

## 🔖 작업 내용
- VoteOption Entity에 코드블럭/언어를 따로 저장
- topic 관련 response와 topic 추가 request dto에 language 필드 추가

## 👀 추가 내용
\+ Topic 저장 request 시 누락되었던 tag 저장 부분 추가하였습니다.
